### PR TITLE
feat: Add user ID metadata to Stripe checkout session

### DIFF
--- a/actions/stripe.ts
+++ b/actions/stripe.ts
@@ -58,6 +58,9 @@ export async function createCheckoutSession(
         mode: "subscription",
         customer: customerId,
         allow_promotion_codes: true,
+        metadata: {
+          userId
+        },
         line_items: [
           {
             price: price,

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: Request) {
   console.log(`[${event.id}][${event.type}]: Event received`)
 
   const permittedEvents = [
+    "checkout.session.completed",
     "customer.subscription.created",
     "customer.subscription.deleted",
     "customer.subscription.updated"


### PR DESCRIPTION
- Include user ID in Stripe checkout session metadata
- Add 'checkout.session.completed' to permitted Stripe webhook events